### PR TITLE
Updated README.md to use @dylanvann/gatsby-remark-cloudinary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add @dylanvann/gatsby-remark-cloudinary
 module.exports = {
     plugins: [
         {
-            resolve: '@dylanvann/gatsby-transformer-cloudinary',
+            resolve: '@dylanvann/gatsby-remark-cloudinary',
             options: {
                 cloudName: '...',
                 apiKey: '...',


### PR DESCRIPTION
First of all, thank you for creating this plugin! I just set this up in a new site I am working on and noticed a small issue in the read me I thought I could help and correct. 
 
I updated the Usage in the README.md to use '@dylanvann/gatsby-remark-cloudinary' and not '@dylanvann/gatsby-transformer-cloudinary'.